### PR TITLE
ci: skip self-assignment

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    if: >-
+      (github.event_name == 'issues' && github.event.issue.user.login != 'jmrplens') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'jmrplens')
     steps:
       - name: Assign to jmrplens
         env:
@@ -19,4 +22,8 @@ jobs:
           REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
-          gh api             --method POST             -H "Accept: application/vnd.github+json"             /repos/$REPO/issues/$NUMBER/assignees             -f assignees[]=jmrplens
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/$REPO/issues/$NUMBER/assignees \
+            -f assignees[]=jmrplens


### PR DESCRIPTION
El workflow ahora no asigna si el autor es @jmrplens.

## Summary by Sourcery

CI:
- Add conditional execution to the auto-assign workflow so it skips when the author is jmrplens.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/FDTDexamples/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

