### PR TITLE
ci: skip dependabot PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,8 +13,8 @@ jobs:
       issues: write
       pull-requests: write
     if: >-
-      (github.event_name == 'issues' && github.event.issue.user.login != 'jmrplens') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'jmrplens')
+      (github.event_name == 'issues' && github.event.issue.user.login != 'jmrplens' && github.event.issue.user.login != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'jmrplens' && github.event.pull_request.user.login != 'dependabot[bot]')
     steps:
       - name: Assign to jmrplens
         env:


### PR DESCRIPTION
Añade filtro para no asignar PRs abiertos por `dependabot[bot]` (además del filtro de auto-asignación).

## Summary by Sourcery

CI:
- Exclude dependabot[bot]-authored issues and pull requests from the auto-assignment GitHub Actions workflow.